### PR TITLE
Relocates resources from incubator org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BOSH Windows Stemcell Builder (DEPRECATED September 2020) [![slack.cloudfoundry.org](https://slack.cloudfoundry.org/badge.svg)](https://slack.cloudfoundry.org)
 
-BOSH Windows Stemcell Builder will be deprecated by September 2020. The recommended approach for creating local BOSH Windows stemcells which can be deployed on [Cloud Foundry BOSH](https://bosh.io), is [`stembuild`](https://github.com/cloudfoundry-incubator/stembuild).
+BOSH Windows Stemcell Builder will be deprecated by September 2020. The recommended approach for creating local BOSH Windows stemcells which can be deployed on [Cloud Foundry BOSH](https://bosh.io), is [`stembuild`](https://github.com/cloudfoundry/stembuild).
 
 [Documentation on how to use `stembuild` can be found here.](https://bosh.io/docs/windows-stemcell-create/)
 
@@ -44,14 +44,14 @@ rake publish:finalize:azure                                                    #
 rake publish:gcp                                                               # Publish an image to GCP
 ```
 
-In Concourse see [Greenhouse CI](https://github.com/cloudfoundry-incubator/greenhouse-ci/tree/master/bosh-windows-stemcell-builder) for required environment variables for these tasks. For example, for `rake build:vsphere` refer to this [task.yml](https://github.com/cloudfoundry-incubator/greenhouse-ci/blob/master/bosh-windows-stemcell-builder/create-vsphere-stemcell-from-vmx/task.yml).
+In Concourse see [Greenhouse CI](https://github.com/cloudfoundry/greenhouse-ci/tree/master/bosh-windows-stemcell-builder) for required environment variables for these tasks. For example, for `rake build:vsphere` refer to this [task.yml](https://github.com/cloudfoundry/greenhouse-ci/blob/master/bosh-windows-stemcell-builder/create-vsphere-stemcell-from-vmx/task.yml).
 
-Instructions for building a manual stemcell for vSphere can be found in the [wiki](https://github.com/cloudfoundry-incubator/bosh-windows-stemcell-builder/wiki/Creating-a-vSphere-Windows-Stemcell).
+Instructions for building a manual stemcell for vSphere can be found in the [wiki](https://github.com/cloudfoundry/bosh-windows-stemcell-builder/wiki/Creating-a-vSphere-Windows-Stemcell).
 
 #### Running the tests
 ```
 bundler exec rspec
 ```
 
-Acceptance testing for stemcells should be done with [bosh-windows-acceptance-tests](https://github.com/cloudfoundry-incubator/bosh-windows-acceptance-tests)
+Acceptance testing for stemcells should be done with [bosh-windows-acceptance-tests](https://github.com/cloudfoundry/bosh-windows-acceptance-tests)
 

--- a/azure-light-stemcell.md
+++ b/azure-light-stemcell.md
@@ -1,1 +1,1 @@
-this page has been moved to the [wiki](https://github.com/cloudfoundry-incubator/bosh-windows-stemcell-builder/wiki/Using-the-Azure-Light-Stemcell)
+this page has been moved to the [wiki](https://github.com/cloudfoundry/bosh-windows-stemcell-builder/wiki/Using-the-Azure-Light-Stemcell)

--- a/create-manual-openstack-stemcells.md
+++ b/create-manual-openstack-stemcells.md
@@ -1,1 +1,1 @@
-this page has been moved to the [wiki](https://github.com/cloudfoundry-incubator/bosh-windows-stemcell-builder/wiki/Create-Manual-OpenStack-Stemcells)
+this page has been moved to the [wiki](https://github.com/cloudfoundry/bosh-windows-stemcell-builder/wiki/Create-Manual-OpenStack-Stemcells)

--- a/create-manual-vsphere-2016-stemcells.md
+++ b/create-manual-vsphere-2016-stemcells.md
@@ -1,1 +1,1 @@
-this page has been moved to the [wiki](https://github.com/cloudfoundry-incubator/bosh-windows-stemcell-builder/wiki/Creating-a-Windows-2016-vSphere-Stemcell-by-Hand)
+this page has been moved to the [wiki](https://github.com/cloudfoundry/bosh-windows-stemcell-builder/wiki/Creating-a-Windows-2016-vSphere-Stemcell-by-Hand)

--- a/create-manual-vsphere-stemcells.md
+++ b/create-manual-vsphere-stemcells.md
@@ -1,1 +1,1 @@
-this page has been moved to the [wiki](https://github.com/cloudfoundry-incubator/bosh-windows-stemcell-builder/wiki/Creating-a-vSphere-Stemcell-by-Hand)
+this page has been moved to the [wiki](https://github.com/cloudfoundry/bosh-windows-stemcell-builder/wiki/Creating-a-vSphere-Stemcell-by-Hand)

--- a/lib/packer/config/gcp.rb
+++ b/lib/packer/config/gcp.rb
@@ -35,7 +35,7 @@ module Packer
                 'winrm_timeout' => '1h',
                 'state_timeout' => '10m',
                 'metadata' => {
-                    'sysprep-specialize-script-url' => 'https://raw.githubusercontent.com/cloudfoundry-incubator/bosh-windows-stemcell-builder/master/scripts/gcp/setup-winrm.ps1',
+                    'sysprep-specialize-script-url' => 'https://raw.githubusercontent.com/cloudfoundry/bosh-windows-stemcell-builder/master/scripts/gcp/setup-winrm.ps1',
                     'name' => "#{@vm_prefix}-#{Time.now.to_i}",
                 }
             }

--- a/manual-stemcell-dotnet-version-guide.md
+++ b/manual-stemcell-dotnet-version-guide.md
@@ -1,1 +1,1 @@
-this page has been moved to the [wiki](https://github.com/cloudfoundry-incubator/bosh-windows-stemcell-builder/wiki/Manual-Stemcell-DotNet-Version-Guide)
+this page has been moved to the [wiki](https://github.com/cloudfoundry/bosh-windows-stemcell-builder/wiki/Manual-Stemcell-DotNet-Version-Guide)

--- a/scripts/aws/setup_winrm.txt
+++ b/scripts/aws/setup_winrm.txt
@@ -1,5 +1,5 @@
 <powershell>
-$winrmUrl = 'https://raw.githubusercontent.com/cloudfoundry-incubator/bosh-psmodules/master/modules/BOSH.WinRM/BOSH.WinRM.psm1'
+$winrmUrl = 'https://raw.githubusercontent.com/cloudfoundry/bosh-psmodules/master/modules/BOSH.WinRM/BOSH.WinRM.psm1'
 
 $dir = 'C:\Program Files\WindowsPowerShell\Modules\BOSH.WinRM'
 New-Item -Path $dir -ItemType Directory -Force

--- a/scripts/gcp/setup-winrm.ps1
+++ b/scripts/gcp/setup-winrm.ps1
@@ -14,7 +14,7 @@ function Write-Log {
    Write-Host $msg
 }
 
-$winrmUrl = 'https://raw.githubusercontent.com/cloudfoundry-incubator/bosh-psmodules/master/modules/BOSH.WinRM/BOSH.WinRM.psm1'
+$winrmUrl = 'https://raw.githubusercontent.com/cloudfoundry/bosh-psmodules/master/modules/BOSH.WinRM/BOSH.WinRM.psm1'
 Write-Log "Making bosh module directory"
 $dir = 'C:\Program Files\WindowsPowerShell\Modules\BOSH.WinRM'
 New-Item -Path $dir -ItemType Directory -Force

--- a/spec/packer/config/gcp_spec.rb
+++ b/spec/packer/config/gcp_spec.rb
@@ -38,7 +38,7 @@ describe Packer::Config::Gcp do
             'winrm_timeout' => '1h',
             'state_timeout' => '10m',
             'metadata' => {
-                'sysprep-specialize-script-url' => 'https://raw.githubusercontent.com/cloudfoundry-incubator/bosh-windows-stemcell-builder/master/scripts/gcp/setup-winrm.ps1',
+                'sysprep-specialize-script-url' => 'https://raw.githubusercontent.com/cloudfoundry/bosh-windows-stemcell-builder/master/scripts/gcp/setup-winrm.ps1',
                 'name' => "some-vm-prefix-#{Time.now.to_i}"
             }
 

--- a/with-concourse.md
+++ b/with-concourse.md
@@ -1,1 +1,1 @@
-this page has been moved to the [wiki](https://github.com/cloudfoundry-incubator/bosh-windows-stemcell-builder/wiki/Windows-Worker-and-Concourse-Setup)
+this page has been moved to the [wiki](https://github.com/cloudfoundry/bosh-windows-stemcell-builder/wiki/Windows-Worker-and-Concourse-Setup)


### PR DESCRIPTION
We discovered that as of a few days ago, the `cloudfoundry-incubator` ->
`cloudfoundry` redirect for several Bosh Windows Stemcell Creator
resources has stopped working. No idea why, but we're pretty sure that
it prevents Packer from downloading the scripts needed to correctly set
up WinRM on the Windows VM that it creates to build the stemcell.

So, this commit corrects the relevant URLs, which will _hopefully_ make
the Windows Stemcell builder pipeline work again.

Signed-off-by: Rajan Agaskar <ragaskar@vmware.com>