### PR TITLE
Fix for the provisioners relying on reflection

### DIFF
--- a/lib/packer/config/provisioners.rb
+++ b/lib/packer/config/provisioners.rb
@@ -2,7 +2,7 @@ require 'securerandom'
 
 class ProvisionerFactory
   def initialize(os, iaas, enable_ephemeral_disk, version, http_proxy = nil, https_proxy = nil, bypass_list = nil, build_context = nil)
-    klass = "Provisioner::OS#{os}"
+    klass = "OS#{os}"
     @provisioner = Object.const_get(klass).new(os, iaas, enable_ephemeral_disk, version, http_proxy, https_proxy, bypass_list, build_context )
   end
 


### PR DESCRIPTION
This fixes:

```
  34) VSphere with patchfile should generate a manifest.yml
      Failure/Error: @provisioner = Object.const_get(klass).new(os, iaas,
      enable_ephemeral_disk, version, http_proxy, https_proxy, bypass_list,
      build_context )

      NameError:
        uninitialized constant Provisioner::OSwindows2019
```