### PR TITLE
CI: Clean up pass constraints for `promote` job.

### DIFF
--- a/ci/pipelines/stemcells-windows.yml
+++ b/ci/pipelines/stemcells-windows.yml
@@ -2323,7 +2323,7 @@ jobs:
               tags: [*worker_tag]
               passed:
                 - wuts-gcp
-                - wuts-aws-govcloud
+                - wuts-aws-govcloud # implies => aws-build-number
                 - wuts-azure
                 - wuts-stembuild-linux-stemcell
                 - wuts-stembuild-windows-stemcell
@@ -2336,7 +2336,7 @@ jobs:
             - get: main-version
               passed:
                 - wuts-gcp
-                - wuts-aws-govcloud
+                - wuts-aws-govcloud  # implies => aws-build-number
                 - wuts-azure
               tags: [*worker_tag]
             - get: packer-output-ami
@@ -2344,7 +2344,7 @@ jobs:
             - get: packer-output-govcloud-ami
               passed: [wuts-aws-govcloud]
             - get: aws-build-number
-              passed: [wuts-aws-govcloud]
+              passed: [wuts-aws-govcloud] # implies => aws-build-number
               tags: [*worker_tag]
             - get: gcp-build-number
               passed: [wuts-gcp]
@@ -2352,7 +2352,7 @@ jobs:
             - get: bosh-agent-release
               passed:
                 - wuts-gcp
-                - wuts-aws-govcloud
+                - wuts-aws-govcloud # implies => aws-build-number
                 - wuts-azure
                 - wuts-stembuild-linux-stemcell
                 - wuts-stembuild-windows-stemcell
@@ -2383,54 +2383,39 @@ jobs:
             - get: bosh-windows-stemcell-builder-ci-image
               tags: [*worker_tag]
             - get: aws-tested
-              passed: [wuts-aws]
+              passed: [print-release-candidate-info]
             - get: aws-govcloud-tested
-              passed: [wuts-aws-govcloud]
+              passed: [print-release-candidate-info]
             - get: gcp-tested
-              passed: [wuts-gcp]
+              passed: [print-release-candidate-info]
             - get: azure-tested
-              passed: [wuts-azure]
+              passed: [print-release-candidate-info]
             - get: azure-base-vhd-uri
-              passed: [wuts-azure]
+              passed: [print-release-candidate-info]
             - get: azure-build-number
-              passed: [wuts-azure]
+              passed: [print-release-candidate-info]
               tags: [*worker_tag]
             - get: stemcell-builder
               tags: [*worker_tag]
-              passed:
-                - wuts-gcp
-                - wuts-aws-govcloud # implies => aws-build-number
-                - wuts-azure
-                - wuts-stembuild-linux-stemcell
-                - wuts-stembuild-windows-stemcell
+              passed: [print-release-candidate-info]
             - get: stembuild-untested-linux
-              passed: [wuts-stembuild-linux-stemcell]
+              passed: [print-release-candidate-info]
             - get: stembuild-linux-stemcell
-              passed: [wuts-stembuild-linux-stemcell]
+              passed: [print-release-candidate-info]
             - get: stembuild-untested-windows
-              passed: [wuts-stembuild-windows-stemcell]
+              passed: [print-release-candidate-info]
             - get: main-version
-              passed:
-                - wuts-gcp
-                - wuts-aws-govcloud # implies => aws-build-number
-                - wuts-azure
-                - print-release-candidate-info
+              passed: [print-release-candidate-info]
               tags: [*worker_tag]
             - get: packer-output-ami
-              passed: [wuts-aws]
+              passed: [print-release-candidate-info]
             - get: packer-output-govcloud-ami
-              passed: [wuts-aws-govcloud]
+              passed: [print-release-candidate-info]
             - get: aws-build-number
-              passed:
-                - wuts-aws-govcloud # implies => aws-build-number
+              passed: [print-release-candidate-info]
               tags: [*worker_tag]
             - get: bosh-agent-release
-              passed:
-                - wuts-gcp
-                - wuts-aws-govcloud # implies => aws-build-number
-                - wuts-azure
-                - wuts-stembuild-linux-stemcell
-                - wuts-stembuild-windows-stemcell
+              passed: [print-release-candidate-info]
       - task: ensure-versions-match
         file: bosh-windows-stemcell-builder-ci/ci/tasks/match-stemcell-versions/task.yml
         image: bosh-windows-stemcell-builder-ci-image


### PR DESCRIPTION
- The pass constraints for `promote` contained many redundant builds that caused the pipeline to render in an incredibly confusing way (and possibly exhibit undesired behavior?).
- This commit simplifies the constraints so it's clear that `promote` takes the last set of inputs that successfully flowed through the `print-release-candidate-info` job.
- Also, "restore' the `# implies => aws-build-number` note that was previously added to the wuts-aws-govcloud pass-constraint in several places on promote but got removed when it was copied to print-release-candidate-info (I am assuming this note is still accurate/relevant).

[TNZ-88995]
ai-assisted=yes